### PR TITLE
feat: `poll_for_tx` status check improvements

### DIFF
--- a/src/clients/coprocessor.rs
+++ b/src/clients/coprocessor.rs
@@ -441,7 +441,7 @@ impl CoprocessorBaseClient for CoprocessorClient {
     }
 
     async fn get_latest_domain_block(&self, domain: &str) -> anyhow::Result<Value> {
-        let uri = format!("registry/domain/{}/latest", domain);
+        let uri = format!("registry/domain/{domain}/latest");
         let uri = self.uri(uri);
         let data = RequestBuilder::new(&uri).get().await?;
 
@@ -449,7 +449,7 @@ impl CoprocessorBaseClient for CoprocessorClient {
     }
 
     async fn add_domain_block(&self, domain: &str, args: &Value) -> anyhow::Result<Value> {
-        let uri = format!("registry/domain/{}", domain);
+        let uri = format!("registry/domain/{domain}");
         let uri = self.uri(uri);
         let data = RequestBuilder::new(&uri).with_args(args).post().await?;
 

--- a/src/clients/noble.rs
+++ b/src/clients/noble.rs
@@ -64,7 +64,7 @@ impl NobleClient {
             .configure_minter_controller(sender, sender, &cctp_module_account_address)
             .await
             .unwrap();
-        info!("Minter controller configured response: {:?}", tx_response);
+        info!("Minter controller configured response: {tx_response:?}");
         self.poll_for_tx(&tx_response.hash).await.unwrap();
 
         // Configure the module account as a minter with a large mint allowance
@@ -72,7 +72,7 @@ impl NobleClient {
             .configure_minter(sender, &cctp_module_account_address, ALLOWANCE, denom)
             .await
             .unwrap();
-        info!("Minter configured response: {:?}", tx_response);
+        info!("Minter configured response: {tx_response:?}");
         self.poll_for_tx(&tx_response.hash).await.unwrap();
 
         // Add a remote token messenger address for the given domain_id.
@@ -84,7 +84,7 @@ impl NobleClient {
         match tx_response {
             Ok(response) => {
                 self.poll_for_tx(&response.hash).await.unwrap();
-                info!("Remote token messenger added response: {:?}", response);
+                info!("Remote token messenger added response: {response:?}");
             }
             Err(_) => {
                 info!("Remote token messenger already added!");
@@ -99,7 +99,7 @@ impl NobleClient {
         match tx_response {
             Ok(response) => {
                 self.poll_for_tx(&response.hash).await.unwrap();
-                info!("Token pair linked response: {:?}", response);
+                info!("Token pair linked response: {response:?}");
             }
             Err(_) => {
                 info!("Token pair already linked!");

--- a/src/clients/valence_indexer.rs
+++ b/src/clients/valence_indexer.rs
@@ -142,5 +142,5 @@ async fn indexer_works() {
         .await
         .unwrap();
 
-    println!("resp: {:?}", resp);
+    println!("resp: {resp:?}");
 }

--- a/src/evm/base_client.rs
+++ b/src/evm/base_client.rs
@@ -169,7 +169,7 @@ pub trait EvmBaseClient: RequestProviderClient {
                     log::info!("query attempt {attempt}/{max_attempts}: condition not met");
                 }
                 Err(e) => {
-                    log::warn!("query attempt {attempt}/{max_attempts} failed: {:?}", e);
+                    log::warn!("query attempt {attempt}/{max_attempts} failed: {e:?}");
                 }
             }
         }


### PR DESCRIPTION
# Description

Improves `poll_for_tx` helper by asserting the response status code to be 0 and returning an error otherwise.

Also clippy+fmt.